### PR TITLE
issue#5 アンサーを編集・削除できるのは投稿者だけにする

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -34,5 +34,6 @@ class AnswersController < ApplicationController
     def set_answer
       @answer = Answer.find(params[:id])
       @question = @answer.question
+      redirect_to root_path unless view_context.login_user?(@answer.user)
     end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,10 @@
 module UsersHelper
+  # ログインユーザーであるか判定
+  def login_user?(user)
+    if user_signed_in?
+      if current_user.id == user.id
+        return true
+      end
+    end
+  end
 end

--- a/app/views/answers/_index.html.erb
+++ b/app/views/answers/_index.html.erb
@@ -5,13 +5,15 @@
       <% unless answer.id.nil? %>
         <li>
           <p class="left"><%= answer.content %></p><p>(<%= link_to answer.user.name, user_path(answer.user.id) %>)</p>
-          <%= link_to "編集", 
-            edit_question_answer_path(answer.question, answer), 
-            class: 'btn btn-default btn-sm btn-success' %>
-          <%= link_to "削除", 
-            question_answer_path(answer.question, answer), 
-            method: :delete, data: { confirm: '本当に削除していいですか？'}, 
-            class: 'btn btn-default btn-sm btn btn-danger' %>
+            <% if login_user?(answer.user) %>
+              <%= link_to "編集", 
+                edit_question_answer_path(answer.question, answer), 
+                class: 'btn btn-default btn-sm btn-success' %>
+              <%= link_to "削除", 
+                question_answer_path(answer.question, answer), 
+                method: :delete, data: { confirm: '本当に削除していいですか？'}, 
+                class: 'btn btn-default btn-sm btn btn-danger' %>
+            <% end %>
             <br><br>
         </li>
       <% end %>


### PR DESCRIPTION
・アンサーを編集・削除できるのは投稿者だけにする仕様を実装

また、編集時のURL（id）を直接書き換えることによって投稿者以外の人が編集できてしまうのはマズイので、コントローラーで監視して投稿者idと現在のログインユーザーidが違った場合はindexにリダイレクトする仕様も加えています。
（ヘルパーメソッドに実引数にuserを入れることでログインユーザーを判定するメソッドを追加したのでもしよければ活用していただけたらと思います）