### PR TITLE
issue#7 仕様の調整

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,4 +1,5 @@
 class AnswersController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_answer, only: [:edit, :update, :destroy]
 
   def create

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,5 @@
 class QuestionsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_question, only: [:show, :edit, :update, :destroy]
 
   # GET /questions

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_for([question,answer]) do |f| %>
+<% if user_signed_in? %>
+  <%= form_for([question,answer]) do |f| %>
     <%= f.hidden_field :question_id %>
     <div class="field">
       <%= f.text_field :content, placeholder: "回答", class: "form-control"  %>
@@ -7,4 +8,4 @@
       <%= f.submit %>
     </div>
   <% end %>
-  
+<% end %>

--- a/app/views/favorite_question/_follow_form.html.erb
+++ b/app/views/favorite_question/_follow_form.html.erb
@@ -1,13 +1,15 @@
-      <% unless FavoriteQuestion.find_by(user_id: current_user.id, question_id: question.id).present? %>
-        <%= form_for(question.favorite_questions.build(user_id: current_user.id, question_id: question.id), url: favorite_questions_path) do |f| %>
-          <%= f.hidden_field :user_id %>
-          <%= f.hidden_field :question_id %>
-          <%= f.submit "投票", class: "btn btn-sm btn-success" %>
-        <% end %>
-      <% else %>
-        <%= form_for(FavoriteQuestion.find_by(user_id: current_user.id, question_id: question.id), url: favorite_question_path(FavoriteQuestion.find_by(user_id: current_user.id, question_id: question.id)),method: :delete) do |f| %>
-          <%= f.hidden_field :user_id %>
-          <%= f.hidden_field :question_id %>
-          <%= f.submit "投票を取り消す", class: "btn btn-sm btn-default"%>
-        <% end %>
-      <% end %>
+<% if user_signed_in? %>
+  <% unless FavoriteQuestion.find_by(user_id: current_user.id, question_id: question.id).present? %>
+    <%= form_for(question.favorite_questions.build(user_id: current_user.id, question_id: question.id), url: favorite_questions_path) do |f| %>
+      <%= f.hidden_field :user_id %>
+      <%= f.hidden_field :question_id %>
+      <%= f.submit "投票", class: "btn btn-sm btn-success" %>
+    <% end %>
+  <% else %>
+    <%= form_for(FavoriteQuestion.find_by(user_id: current_user.id, question_id: question.id), url: favorite_question_path(FavoriteQuestion.find_by(user_id: current_user.id, question_id: question.id)),method: :delete) do |f| %>
+      <%= f.hidden_field :user_id %>
+      <%= f.hidden_field :question_id %>
+      <%= f.submit "投票を取り消す", class: "btn btn-sm btn-default"%>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -12,6 +12,4 @@
       </span>
     <% end %>
   <% end %>
-<% else %>
- <%= link_to new_user_session_path ,class: "fa fa-star-o" %>
 <% end %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,4 +1,3 @@
-<p id="notice"><%= notice %></p>
 <div class="container-fluid">
   <div class="row">
     <div class="col-md-1"></div>
@@ -16,10 +15,10 @@
       <tr>
       <td><%= render partial: 'favorite_question/follow_form', locals: { question: question }  %></td>
         <td><div class="btn btn-default btn-sm">質問貢献度:<%= FavoriteQuestion.where(question_id:question).count %></div></td>
-        <% if current_user.id == question.user_id%>
-        <td><%= link_to '編集', edit_question_path(question),class: "btn btn-sm btn-default" %></td>
-        <td><%= link_to '削除', question, method: :delete, data: { confirm: 'Are you sure?' },class: "btn btn-sm btn-default" %></td>
-        <%end%>
+        <% if login_user?(question.user) %>
+          <td><%= link_to '編集', edit_question_path(question),class: "btn btn-sm btn-default" %></td>
+          <td><%= link_to '削除', question, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-default" %></td>
+        <% end %>
 
       </tr>
     <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Title:</strong>
   <%= @question.title %>
@@ -12,8 +10,9 @@
 
 <%= render partial: 'answers/index', locals: { answers: @answers, question: @question } %>
 <%= render partial: 'answers/form', locals: { answer: @answer, question: @question } %>
+
 <div id="favorites-button">
-<%= render partial: 'favorites/favorite', locals: { question: @question} %>
+  <%= render partial: 'favorites/favorite', locals: { question: @question} %>
 </div>
 
 <%= link_to 'Edit', edit_question_path(@question) %> |

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,36 +1,36 @@
-<p id="notice"><%= notice %></p>
-<div class="container-fluid">
-  <div class="row">
-    <div class="col-md-1"></div>
-    <div class="col-md-8">
+# <p id="notice"><%= notice %></p>
+# <div class="container-fluid">
+#   <div class="row">
+#     <div class="col-md-1"></div>
+#     <div class="col-md-8">
 
-<table>
+# <table>
 
-  <tbody>
-    <% @questions.each do |question| %>
-      <tr>
-        <td><%= link_to question_path(question) do %>
-          <div class="btn btn-block "><h4><strong><%= question.title %></strong></h4></div>
-        <% end %></td>
-      </tr>
-      <tr>
-      <td><%= render partial: 'favorite_question/follow_form', locals: { question: question }  %></td>
-        <td><div class="btn btn-default btn-sm">質問貢献度:<%= FavoriteQuestion.where(question_id:question).count %></div></td>
-        <% if current_user.id == question.user_id%>
-        <td><%= link_to '編集', edit_question_path(question),class: "btn btn-sm btn-default" %></td>
-        <td><%= link_to '削除', question, method: :delete, data: { confirm: 'Are you sure?' } ,class: "btn btn-sm btn-default"%></td>
-        <%end%>
+#   <tbody>
+#     <% @questions.each do |question| %>
+#       <tr>
+#         <td><%= link_to question_path(question) do %>
+#           <div class="btn btn-block "><h4><strong><%= question.title %></strong></h4></div>
+#         <% end %></td>
+#       </tr>
+#       <tr>
+#       <td><%= render partial: 'favorite_question/follow_form', locals: { question: question }  %></td>
+#         <td><div class="btn btn-default btn-sm">質問貢献度:<%= FavoriteQuestion.where(question_id:question).count %></div></td>
+#         <% if login_user?(question.user)%>
+#           <td><%= link_to '編集', edit_question_path(question),class: "btn btn-sm btn-default" %></td>
+#           <td><%= link_to '削除', question, method: :delete, data: { confirm: 'Are you sure?' } ,class: "btn btn-sm btn-default"%></td>
+#         <%end%>
 
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+#       </tr>
+#     <% end %>
+#   </tbody>
+# </table>
 
-<br>
+# <br>
 
 
-    </div>
-    <div class="col-md-3"><%= link_to '質問をする', new_question_path,class: "btn btn-sm btn-primary" %></div>
-  </div>
-</div>
+#     </div>
+#     <div class="col-md-3"><%= link_to '質問をする', new_question_path,class: "btn btn-sm btn-primary" %></div>
+#   </div>
+# </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :favorites, only:[:index]
 
   devise_for :users
-  root 'top#index'
+  root 'questions#index'
 
   resources :users, only: [:index, :show]
 


### PR DESCRIPTION
誰であっても描写についてとその他細かい整形を行いました。

・「ユーザー質問のindex, show（CRUDのうちRのみ）」
・「ユーザー回答のindex, show（CRUDのうちRのみ）」
→私の担当は主に回答ですが、他の調整との兼ね合いで質問側も実装しました（バッティングしたら申し訳ないです）

・回答のCリンク（RUDは除く）
→こちらは非ログイン時には回答フォームを表示しないようにしました。
（参考元が回答時にログインを促すような仕様ですので、後に調整するかもしれません）

・非ログイン時に発生するエラーの解消
→<user_signed_in?>メソッドによって分岐させていなかった為に発生していたエラーを解消

・top/indexとguestions/indexが同じ内容で混在していたために統合

・レイアウト側でnoticeが記述されているので、個別ページで記述されているnoticeは全削除

・ログインユーザと投稿ユーザが一致しているかを確かめる記述は、以前に作成したヘルパーメソッドに統一